### PR TITLE
Add dnsmasq_etc_default_options var

### DIFF
--- a/templates/etc/default/dnsmasq.j2
+++ b/templates/etc/default/dnsmasq.j2
@@ -53,3 +53,7 @@ IGNORE_RESOLVCONF={{ dnsmasq_etc_default_ignore_resolvconf | bool | ternary('yes
 {% else %}
 #IGNORE_RESOLVCONF=yes
 {% endif %}
+
+{% for line in dnsmasq_etc_default_options | default([]) %}
+{{ line }}
+{% endfor %}


### PR DESCRIPTION
Addresses issue #5

* Adds `dnsmasq_etc_default_options` which appends lines to
/etc/default/dnsmasq